### PR TITLE
update kmalloc syscall

### DIFF
--- a/ch05/kmalloc/README.md
+++ b/ch05/kmalloc/README.md
@@ -1,0 +1,13 @@
+# Usage - Kmalloc
+
+test kmalloc syscall:
+```sh
+make
+sudo kldload ./module/kmalloc.ko
+./interface/interface 4
+```
+
+unload kmalloc syscall:
+```sh
+sudo kldunload ./module/kmalloc.ko
+```

--- a/ch05/kmalloc/interface/interface.c
+++ b/ch05/kmalloc/interface/interface.c
@@ -28,6 +28,8 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/module.h>
@@ -46,11 +48,11 @@ main(int argc, char *argv[])
 	}
 
 	stat.version = sizeof(stat);
-	modstat(modfind("kmalloc"), &stat);
+	modstat(modfind("sys/kmalloc"), &stat);
 	syscall_num = stat.data.intval;
 
 	syscall(syscall_num, (unsigned long)atoi(argv[1]), &addr);
-	printf("Address of allocated kernel memory: 0x%x\n", addr);
+	printf("Address of allocated kernel memory: 0x%lx\n", addr);
 
 	exit(0);
 }

--- a/ch05/kmalloc/module/kmalloc.c
+++ b/ch05/kmalloc/module/kmalloc.c
@@ -34,6 +34,7 @@
 #include <sys/sysent.h>
 #include <sys/kernel.h>
 #include <sys/systm.h>
+#include <sys/sysproto.h>
 #include <sys/malloc.h>
 
 struct kmalloc_args {
@@ -51,7 +52,7 @@ kmalloc(struct thread *td, void *syscall_args)
 	int error;
 	unsigned long addr;
 
-	MALLOC(addr, unsigned long, uap->size, M_TEMP, M_NOWAIT);
+	addr = (unsigned long)malloc(uap->size, M_TEMP, M_NOWAIT);
 	error = copyout(&addr, uap->addr, sizeof(addr));
 
 	return(error);


### PR DESCRIPTION
this is the first change for the repo.
Here is the changes:

- add a readme for usage
- interface.c: add includes for exit, syscall ...
- interface.c: add "l" to "0x%x" in printf, avoid warnings
- kmalloc.c: change macro to function malloc